### PR TITLE
Add safe mode if a user fail to start orbisgis

### DIFF
--- a/orbisgis-dist/src/bin/zip/orbisgis_safemode.sh
+++ b/orbisgis-dist/src/bin/zip/orbisgis_safemode.sh
@@ -1,0 +1,30 @@
+#
+# OrbisGIS is a GIS application dedicated to scientific spatial simulation.
+# This cross-platform GIS is developed at French IRSTV institute and is able to
+# manipulate and create vector and raster spatial information.
+#
+# OrbisGIS is distributed under GPL 3 license. It is produced by the "Atelier SIG"
+# team of the IRSTV Institute <http://www.irstv.fr/> CNRS FR 2488.
+#
+# Copyright (C) 2007-2012 IRSTV (FR CNRS 2488)
+#
+# This file is part of OrbisGIS.
+#
+# OrbisGIS is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# OrbisGIS is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# OrbisGIS. If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information, please consult: <http://www.orbisgis.org/>
+# or contact directly:
+# info_at_ orbisgis.org
+#
+
+java -Xmx1024M -jar orbisgis.jar $* --nofailmode

--- a/orbisgis-dist/src/bin/zip/orbisgis_windows_safemode.bat
+++ b/orbisgis-dist/src/bin/zip/orbisgis_windows_safemode.bat
@@ -1,0 +1,2 @@
+java -jar -Xmx1024M -jar orbisgis.jar --nofailmode
+pause


### PR DESCRIPTION
Add safe mode shortcut (option) if a user fail to start orbisgis. Clear the OSGi bundle cache folder.