### PR TITLE
Set a maximum length to overlay

### DIFF
--- a/orbisgis-sif/src/main/java/org/orbisgis/sif/components/MessageOverlay.java
+++ b/orbisgis-sif/src/main/java/org/orbisgis/sif/components/MessageOverlay.java
@@ -43,6 +43,7 @@ public class MessageOverlay extends LayerUI<Container> implements ImageObserver 
     private Font messageFont;
     private long lastMessageUpdate = 0;
     public enum MESSAGE_TYPE { INFO, ERROR}
+    private Rectangle2D cachedTextSize = null;
 
     public MessageOverlay(int maxLength) {
         max_length = maxLength;
@@ -98,7 +99,11 @@ public class MessageOverlay extends LayerUI<Container> implements ImageObserver 
         Graphics2D g2 = (Graphics2D)g.create();
         g2.setFont(messageFont);
         FontMetrics fm = g2.getFontMetrics();
-        Rectangle2D textSize = fm.getStringBounds(message, g2);
+        Rectangle2D textSize = cachedTextSize;
+        if(textSize == null) {
+            cachedTextSize = fm.getStringBounds(message, g2);
+            textSize = cachedTextSize;
+        }
         float fade = Math.max(0, Math.min(1, (float) interpolationCount / (float) INTERPOLATION_MAX));
         Composite urComposite = g2.getComposite();
         // Set alpha
@@ -147,6 +152,7 @@ public class MessageOverlay extends LayerUI<Container> implements ImageObserver 
      */
     public void setMessage(String message, MESSAGE_TYPE message_type) {
         this.message = message.substring(0, Math.min(message.length(),max_length));
+        cachedTextSize = null;
         switch (message_type) {
             case ERROR:
                 icon = iconError;

--- a/orbisgis-sif/src/main/java/org/orbisgis/sif/components/MessageOverlay.java
+++ b/orbisgis-sif/src/main/java/org/orbisgis/sif/components/MessageOverlay.java
@@ -23,6 +23,8 @@ import java.beans.PropertyChangeEvent;
  * @author Nicolas Fortin
  */
 public class MessageOverlay extends LayerUI<Container> implements ImageObserver {
+    private final static int DEFAULT_MAX_LENGTH = 120;
+    private final int max_length;
     private static final int INTERPOLATION_MAX = 4;
     private static final float LAYER_OPACITY = 0.75f;
     /** Stop the overlay if the message has not change during this time */
@@ -42,13 +44,17 @@ public class MessageOverlay extends LayerUI<Container> implements ImageObserver 
     private long lastMessageUpdate = 0;
     public enum MESSAGE_TYPE { INFO, ERROR}
 
-    public MessageOverlay() {
+    public MessageOverlay(int maxLength) {
+        max_length = maxLength;
         iconInfo = new ImageIcon(MessageOverlay.class.getResource("info.gif"));
         iconInfo.setImageObserver(this);
         iconError = new ImageIcon(MessageOverlay.class.getResource("error.gif"));
         iconError.setImageObserver(this);
         icon = iconInfo;
         messageFont = new JLabel().getFont().deriveFont(Font.BOLD);
+    }
+    public MessageOverlay() {
+        this(DEFAULT_MAX_LENGTH);
     }
 
     @Override
@@ -140,7 +146,7 @@ public class MessageOverlay extends LayerUI<Container> implements ImageObserver 
      * @param message Shown message
      */
     public void setMessage(String message, MESSAGE_TYPE message_type) {
-        this.message = message;
+        this.message = message.substring(0, Math.min(message.length(),max_length));
         switch (message_type) {
             case ERROR:
                 icon = iconError;


### PR DESCRIPTION
Set a maximum length to error message overlay in order to not freeze ui on long sql error message.